### PR TITLE
Add Organizr as home server dashboard alternative

### DIFF
--- a/content/2025/03/must-have-home-server-services-2025/index.md
+++ b/content/2025/03/must-have-home-server-services-2025/index.md
@@ -342,7 +342,7 @@ Like InfluxDB this is a data collection tool for monitoring and data analytics. 
 
 ### Alternatives and Extras
 Dashboards
-- (alt to Glance/Homarr)
+- [Organizr](https://github.com/causefx/Organizr) (alt to Glance/Homarr)
 
 Tools and Utilities
 - (alt to File Browser)


### PR DESCRIPTION
Added Organizr to the Alternatives and Extras section as a dashboard option for easily accessing *arr stack services.
[https://github.com/TechHutTV/techhut.tv/issues/1](https://github.com/TechHutTV/techhut.tv/issues/1)