### PR TITLE
Change zpool command to use disk by-id paths

### DIFF
--- a/content/2025/12/fedora-server-guide-cockpit-zfs-podman/index.md
+++ b/content/2025/12/fedora-server-guide-cockpit-zfs-podman/index.md
@@ -460,7 +460,7 @@ sudo zpool labelclear -f /dev/sdc
 ### Create the Mirror Pool
 
 ```bash
-sudo zpool create -m /data data mirror /dev/sdb /dev/sdc
+sudo zpool create -m /data data mirror /dev/disk/by-id/... /dev/disk/by-id/...
 ```
 
 This creates a pool named `data` mounted at `/data`. Replace `/dev/sdb` and `/dev/sdc` with your actual drive paths—use `lsblk` to identify them and make sure you're not formatting your OS drive.


### PR DESCRIPTION
Updated the zpool create command to use disk by-id paths for better reliability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update ZFS mirror creation command to use persistent /dev/disk/by-id paths instead of volatile /dev/sdX device names.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f532dcb5c7882f52223576bf5482d1ffd2f0884. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->